### PR TITLE
Fix Databricks Workspace path handling in Python-to-SQL conversion

### DIFF
--- a/sql2dbx/notebooks/06_convert_to_sql_notebooks.py
+++ b/sql2dbx/notebooks/06_convert_to_sql_notebooks.py
@@ -26,15 +26,18 @@
 # COMMAND ----------
 
 # DBTITLE 1,Import Libraries
-import json
-import os
 import base64
-from typing import List, Dict, Any, Tuple
+import json
+from typing import Any, Dict, List, Tuple
+
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import workspace
-from pyscripts.batch_inference_helper import (AsyncChatClient,
-                                              BatchInferenceManager,
-                                              BatchInferenceRequest)
+
+from pyscripts.batch_inference_helper import (
+    AsyncChatClient,
+    BatchInferenceManager,
+    BatchInferenceRequest,
+)
 from pyscripts.conversion_prompt_helper import ConversionPromptHelper
 
 # COMMAND ----------
@@ -381,13 +384,11 @@ if sql_notebooks:
             # Determine output path for SQL notebook
             relative_path = notebook["relative_path"]
             
-            # Change extension from .py to .sql
-            if relative_path.endswith('.py'):
-                sql_relative_path = relative_path[:-3] + '.sql'
-            else:
-                sql_relative_path = relative_path + '.sql'
+            # Databricks workspace notebook paths don't have extensions
+            # Just use the same path for SQL output
+            sql_relative_path = relative_path
             
-            sql_output_path = os.path.join(sql_output_dir, sql_relative_path).replace('\\', '/')
+            sql_output_path = f"{sql_output_dir.rstrip('/')}/{sql_relative_path}"
             
             # Export notebook directly using WorkspaceClient
             w = WorkspaceClient()


### PR DESCRIPTION
- Replace os.path.join() with f-string for workspace path construction
- Remove unnecessary .sql extension handling for workspace notebooks
- Clean up import statements (remove unused os import, reorganize imports)
- Improve path reliability for Databricks workspace operations

Tested with multiple job executions including custom prompt configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)